### PR TITLE
Fix default redis url parsing

### DIFF
--- a/src/projects/host_chat/hippocampus.py
+++ b/src/projects/host_chat/hippocampus.py
@@ -26,7 +26,8 @@ class Hippocampus:
         host = parsed_url.hostname
         port = parsed_url.port
         qs = {k: v[0] for k, v in parse_qs(parsed_url.query).items()}
-        self.redis_client = redis.StrictRedis(host=host, port=port, db=int(qs["db"]))
+        db = int(qs.get("db", "0"))
+        self.redis_client = redis.StrictRedis(host=host, port=port, db=db)
 
     def _count_token(self, content: str) -> int:
         encoding = tiktoken.get_encoding("cl100k_base")

--- a/src/projects/host_chat/main.py
+++ b/src/projects/host_chat/main.py
@@ -49,7 +49,8 @@ class ChatHostClient:
 
     async def connect_mcp_servers(self):
         """Connect to mcp servers"""
-        self.hippocampus.memory_established(os.getenv("REDIS_URL", ""))
+        redis_url = os.getenv("REDIS_URL", "redis://localhost:6379?db=0")
+        self.hippocampus.memory_established(redis_url)
         await self.findxai_client.connect_to_server()
         tools = await load_mcp_tools(self.findxai_client.get_session())
         self.agent = create_react_agent(


### PR DESCRIPTION
## Summary
- add fallback db index when parsing redis url
- use default redis connection if env var is missing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684132421e04832e9ebd3234215343d1